### PR TITLE
Add support for proxy URL in ClientOptions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "camelcase": "^6.3.0",
         "debug": "^4.3.4",
+        "fetch-socks": "^1.3.0",
         "tslib": "^2.6.2",
         "ws": "^8.16.0"
       },
@@ -25,7 +26,7 @@
         "@semantic-release/release-notes-generator": "11.0.1",
         "@types/debug": "4.1.12",
         "@types/jest": "29.5.12",
-        "@types/node": "^20.12.7",
+        "@types/node": "^20.14.14",
         "@types/ws": "^8.5.10",
         "@typescript-eslint/eslint-plugin": "7.6.0",
         "@typescript-eslint/parser": "7.6.0",
@@ -1950,6 +1951,20 @@
         "semantic-release": ">=18.0.0-beta.1"
       }
     },
+    "node_modules/@semantic-release/github/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/@semantic-release/npm": {
       "version": "10.0.3",
       "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-10.0.3.tgz",
@@ -2573,10 +2588,11 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.12.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.7.tgz",
-      "integrity": "sha512-wq0cICSkRLVaf3UGLMGItu/PtdY7oaXaI/RVU+xliKVOtRna3PRY57ZDfztpDL0n11vfymMUnXv8QwYCO7L1wg==",
+      "version": "20.14.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.14.tgz",
+      "integrity": "sha512-d64f00982fS9YoOgJkAMolK7MN8Iq3TDdVjchbYHdEmjth/DHowx82GnoA+tVUAN+7vxfYUgAzi+JXbKNd2SDQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -6034,6 +6050,16 @@
         "bser": "2.1.1"
       }
     },
+    "node_modules/fetch-socks": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fetch-socks/-/fetch-socks-1.3.0.tgz",
+      "integrity": "sha512-Cq7O53hoNiVeOs6u54f8M/H/w2yzhmnTQ3tcAJj9FNKYOeNGmt8qNU1zpWOzJD09f0uqfmBXxLbzWPsnT6GcRw==",
+      "license": "MIT",
+      "dependencies": {
+        "socks": "^2.8.1",
+        "undici": "^6.10.1"
+      }
+    },
     "node_modules/figures": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-5.0.0.tgz",
@@ -6652,19 +6678,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "dev": true,
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/human-signals": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
@@ -6823,6 +6836,25 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/ip-address": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
+      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+      "license": "MIT",
+      "dependencies": {
+        "jsbn": "1.1.0",
+        "sprintf-js": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ip-address/node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/is-array-buffer": {
       "version": "3.0.4",
@@ -7970,6 +8002,12 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
+    },
+    "node_modules/jsbn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
+      "license": "MIT"
     },
     "node_modules/jsesc": {
       "version": "3.0.2",
@@ -14115,6 +14153,30 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
+      "integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^9.0.5",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -15053,6 +15115,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici": {
+      "version": "6.19.5",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.19.5.tgz",
+      "integrity": "sha512-LryC15SWzqQsREHIOUybavaIHF5IoL0dJ9aWWxL/PgT1KfqAW5225FZpDUFlt9xiDMS2/S7DOKhFWA7RLksWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {
@@ -16922,6 +16993,18 @@
         "p-filter": "^2.0.0",
         "p-retry": "^4.0.0",
         "url-join": "^4.0.0"
+      },
+      "dependencies": {
+        "https-proxy-agent": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+          "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+          "dev": true,
+          "requires": {
+            "agent-base": "6",
+            "debug": "4"
+          }
+        }
       }
     },
     "@semantic-release/npm": {
@@ -17383,9 +17466,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "20.12.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.7.tgz",
-      "integrity": "sha512-wq0cICSkRLVaf3UGLMGItu/PtdY7oaXaI/RVU+xliKVOtRna3PRY57ZDfztpDL0n11vfymMUnXv8QwYCO7L1wg==",
+      "version": "20.14.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.14.tgz",
+      "integrity": "sha512-d64f00982fS9YoOgJkAMolK7MN8Iq3TDdVjchbYHdEmjth/DHowx82GnoA+tVUAN+7vxfYUgAzi+JXbKNd2SDQ==",
       "dev": true,
       "requires": {
         "undici-types": "~5.26.4"
@@ -19812,6 +19895,15 @@
         "bser": "2.1.1"
       }
     },
+    "fetch-socks": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fetch-socks/-/fetch-socks-1.3.0.tgz",
+      "integrity": "sha512-Cq7O53hoNiVeOs6u54f8M/H/w2yzhmnTQ3tcAJj9FNKYOeNGmt8qNU1zpWOzJD09f0uqfmBXxLbzWPsnT6GcRw==",
+      "requires": {
+        "socks": "^2.8.1",
+        "undici": "^6.10.1"
+      }
+    },
     "figures": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-5.0.0.tgz",
@@ -20258,16 +20350,6 @@
         "debug": "4"
       }
     },
-    "https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "dev": true,
-      "requires": {
-        "agent-base": "6",
-        "debug": "4"
-      }
-    },
     "human-signals": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
@@ -20373,6 +20455,22 @@
       "requires": {
         "from2": "^2.3.0",
         "p-is-promise": "^3.0.0"
+      }
+    },
+    "ip-address": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
+      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+      "requires": {
+        "jsbn": "1.1.0",
+        "sprintf-js": "^1.1.3"
+      },
+      "dependencies": {
+        "sprintf-js": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+          "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="
+        }
       }
     },
     "is-array-buffer": {
@@ -21214,6 +21312,11 @@
       "requires": {
         "argparse": "^2.0.1"
       }
+    },
+    "jsbn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A=="
     },
     "jsesc": {
       "version": "3.0.2",
@@ -25521,6 +25624,20 @@
         }
       }
     },
+    "smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="
+    },
+    "socks": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
+      "integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
+      "requires": {
+        "ip-address": "^9.0.5",
+        "smart-buffer": "^4.2.0"
+      }
+    },
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -26194,6 +26311,11 @@
         "has-symbols": "^1.0.3",
         "which-boxed-primitive": "^1.0.2"
       }
+    },
+    "undici": {
+      "version": "6.19.5",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.19.5.tgz",
+      "integrity": "sha512-LryC15SWzqQsREHIOUybavaIHF5IoL0dJ9aWWxL/PgT1KfqAW5225FZpDUFlt9xiDMS2/S7DOKhFWA7RLksWdg=="
     },
     "undici-types": {
       "version": "5.26.5",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "camelcase": "^6.3.0",
     "debug": "^4.3.4",
+    "fetch-socks": "^1.3.0",
     "tslib": "^2.6.2",
     "ws": "^8.16.0"
   },
@@ -40,7 +41,7 @@
     "@semantic-release/release-notes-generator": "11.0.1",
     "@types/debug": "4.1.12",
     "@types/jest": "29.5.12",
-    "@types/node": "^20.12.7",
+    "@types/node": "^20.14.14",
     "@types/ws": "^8.5.10",
     "@typescript-eslint/eslint-plugin": "7.6.0",
     "@typescript-eslint/parser": "7.6.0",

--- a/src/gateway/__tests__/unit/gateway.test.ts
+++ b/src/gateway/__tests__/unit/gateway.test.ts
@@ -1,0 +1,49 @@
+import { Agent } from "undici";
+
+import { AnonGateway } from "../../anon";
+
+describe("Gateway", () => {
+  describe("buildOptions()", () => {
+    it("should throw an error for unsupported proxy URL", async () => {
+      const gateway = new AnonGateway(
+        "fake-user-agent",
+        "http://proxy.example.com",
+      );
+      await expect(gateway["buildOptions"]()).rejects.toThrow(
+        "Only socks proxies are supported. Provide an URL like 'socks5://",
+      );
+    });
+
+    it("should return options with socks5 proxy agent", async () => {
+      const gateway = new AnonGateway(
+        "fake-user-agent",
+        "socks5://proxy.example.com:1080",
+      );
+      const options = await gateway["buildOptions"]();
+
+      expect(options.agent).toBeInstanceOf(Agent);
+    });
+
+    it("should return options without proxy agent if proxy URL is not provided", async () => {
+      const gateway = new AnonGateway("fake-user-agent");
+      const options = await gateway["buildOptions"]();
+
+      expect(options.agent).toBeUndefined();
+    });
+
+    it("should return options without proxy agent if proxy URL is empty", async () => {
+      const gateway = new AnonGateway("fake-user-agent", "");
+      const options = await gateway["buildOptions"]();
+
+      expect(options.agent).toBeUndefined();
+    });
+
+    it("should return options without proxy agent if proxy URL is null", async () => {
+      // eslint-disable-next-line unicorn/no-null
+      const gateway = new AnonGateway("fake-user-agent", null);
+      const options = await gateway["buildOptions"]();
+
+      expect(options.agent).toBeUndefined();
+    });
+  });
+});

--- a/src/gateway/anon.ts
+++ b/src/gateway/anon.ts
@@ -3,8 +3,8 @@ import { Gateway } from "./gateway";
 /** @internal */
 export class AnonGateway extends Gateway {
   /** @internal */
-  constructor(userAgent: string) {
-    super("https://www.reddit.com", userAgent);
+  constructor(userAgent: string, proxyUrl?: string | null) {
+    super("https://www.reddit.com", userAgent, proxyUrl);
   }
 
   protected async auth(): Promise<undefined> {

--- a/src/gateway/creds.ts
+++ b/src/gateway/creds.ts
@@ -31,8 +31,8 @@ export class CredsGateway extends Gateway {
   protected creds: Credentials;
 
   /** @internal */
-  constructor(creds: Credentials, userAgent: string) {
-    super("https://www.reddit.com", userAgent);
+  constructor(creds: Credentials, userAgent: string, proxyUrl?: string | null) {
+    super("https://www.reddit.com", userAgent, proxyUrl);
     this.creds = creds;
   }
 

--- a/src/gateway/oauth.ts
+++ b/src/gateway/oauth.ts
@@ -94,8 +94,13 @@ export class OauthGateway extends Gateway {
   }
 
   /** @internal */
-  constructor(auth: Maybe<ClientAuth>, creds: Credentials, userAgent: string) {
-    super("https://oauth.reddit.com", userAgent);
+  constructor(
+    auth: Maybe<ClientAuth>,
+    creds: Credentials,
+    userAgent: string,
+    proxyUrl?: string | null,
+  ) {
+    super("https://oauth.reddit.com", userAgent, proxyUrl);
     this.initialAuth = auth;
     this.creds = creds;
   }

--- a/src/gateway/types.ts
+++ b/src/gateway/types.ts
@@ -1,3 +1,5 @@
+import type { ProxyAgent } from "undici";
+
 /**
  * Options for configuring the Shim.
  */
@@ -20,6 +22,7 @@ export type ShimOptions = {
   password?: string;
   form?: Record<string, string>;
   json?: Record<string, string>;
+  agent?: ProxyAgent;
 };
 
 /** The types of values that are allowed in a query. */


### PR DESCRIPTION
This pull request adds support for specifying a proxy URL in the `ClientOptions` interface. It includes changes to the `ClientOptions` interface, the `CredsGateway` constructor, the `AnonGateway` constructor, and the `OauthGateway` constructor. The `Client` class has also been updated to pass the `proxyUrl` option to the appropriate gateway constructor. Additionally, a new test case has been added to ensure that the gateway correctly handles different types of proxy URLs.